### PR TITLE
feat(company): retrieve paginated company contracts

### DIFF
--- a/src/company/company.controller.ts
+++ b/src/company/company.controller.ts
@@ -28,13 +28,14 @@ import { GetFile } from '@common/interceptors/file.interceptor';
 import { CreateCompanyContractDto } from './dtos/create-company-contract-request.dto';
 import { CompanyContractResponseDto } from './dtos/company-contract-response.dto';
 import { UpdateCompanyContractDto } from './dtos/update-company-contract.dto';
+import { CompanyContractFilterDto } from './dtos/company-contract-filter.dto';
 
 @Controller('companies')
 export class CompanyController {
   constructor(
     private readonly companyService: CompanyService,
     private readonly companyContractService: CompanyContractService,
-  ) {}
+  ) { }
 
   @Post('create')
   @UseGuards(AuthGuard, RoleGuard)
@@ -110,6 +111,19 @@ export class CompanyController {
       dto,
       companyId,
       file,
+    );
+  }
+
+  @UseGuards(AuthGuard, RoleGuard)
+  @Roles(UserRole.ADMIN)
+  @Get(':companyId/contracts')
+  async getCompanyContracts(
+    @Param('companyId', ParseObjectIdPipe) companyId: string,
+    @Query() filter: CompanyContractFilterDto,
+  ): Promise<PaginatedResult<CompanyContractResponseDto>> {
+    return this.companyContractService.getCompanyContractsByCriteria(
+      companyId,
+      filter,
     );
   }
 

--- a/src/company/dtos/company-contract-filter.dto.ts
+++ b/src/company/dtos/company-contract-filter.dto.ts
@@ -1,0 +1,14 @@
+import { PaginationQueryDto } from "@common/dtos/pagination-query.dto";
+import { IsEnum, IsOptional } from "class-validator";
+import { CompanyContractStatus } from "company/enums/company-contract-status.enum";
+import { CompanyContractType } from "company/enums/company-contract-type.enum";
+
+export class CompanyContractFilterDto extends PaginationQueryDto {
+    @IsOptional()
+    @IsEnum(CompanyContractStatus)
+    status?: CompanyContractStatus
+
+    @IsOptional()
+    @IsEnum(CompanyContractType)
+    type?: CompanyContractType
+}


### PR DESCRIPTION
This pull request introduces functionality to filter and paginate company contracts based on specific criteria. It includes updates to the `CompanyContractService`, `CompanyController`, and the addition of a new DTO (`CompanyContractFilterDto`). The most important changes are grouped into service enhancements, controller updates, and DTO additions.

### Service Enhancements:
* Added a method `getCompanyContractsByCriteria` in `CompanyContractService` to retrieve filtered and paginated company contracts. This method validates the company existence, builds a query based on the filter criteria, and uses pagination to fetch results.
* Introduced a private helper method `buildFilterQuery` in `CompanyContractService` to construct a query object based on the provided filter criteria (`status` and `type`).

### Controller Updates:
* Added a new endpoint `GET :companyId/contracts` in `CompanyController` to allow administrators to fetch company contracts using filter criteria and pagination. This endpoint uses guards for authentication and role-based access control.

### DTO Additions:
* Created `CompanyContractFilterDto` to define the structure of the filter criteria, including optional `status` and `type` fields with validation, extending `PaginationQueryDto` for pagination support.