### PR TITLE
hotfix(company): typeahead endpoind

### DIFF
--- a/src/company/company.controller.ts
+++ b/src/company/company.controller.ts
@@ -46,6 +46,13 @@ export class CompanyController {
     return this.companyService.createCompany(dto);
   }
 
+  @Get('/typeahead')
+  @UseGuards(AuthGuard)
+  async getTypeahead(@Query('query') query: string): Promise<TypeaheadItem[]> {
+    return this.companyService.getCompanyTypeahead(query);
+  }
+
+
   @Get(':companyId')
   async getCompanyById(
     @Param('companyId', ParseObjectIdPipe) companyId: string,
@@ -92,11 +99,6 @@ export class CompanyController {
     return this.companyService.getByCriteria(filter);
   }
 
-  @Get('/typeahead')
-  @UseGuards(AuthGuard)
-  async getTypeahead(@Query('query') query: string): Promise<TypeaheadItem[]> {
-    return this.companyService.getCompanyTypeahead(query);
-  }
 
   @UseGuards(AuthGuard, RoleGuard)
   @Roles(UserRole.ADMIN)


### PR DESCRIPTION
This pull request makes changes to the `CompanyController` class in `src/company/company.controller.ts`, specifically related to the `getTypeahead` method. The changes involve moving the method to a different location within the class for better organization.

Reorganization of `getTypeahead` method:

* [`src/company/company.controller.ts`](diffhunk://#diff-edf40b2539d56fcef947a4daddbecf71218c9e8009d6783df31de9df22340a3eR49-R55): The `getTypeahead` method, which handles typeahead functionality for companies, was relocated within the `CompanyController` class. It was previously placed after the `getByCriteria` method and is now positioned after the `createCompany` method. This change improves the logical grouping of methods in the controller. [[1]](diffhunk://#diff-edf40b2539d56fcef947a4daddbecf71218c9e8009d6783df31de9df22340a3eR49-R55) [[2]](diffhunk://#diff-edf40b2539d56fcef947a4daddbecf71218c9e8009d6783df31de9df22340a3eL95-L99)