### PR TITLE
Feature/student company contract

### DIFF
--- a/src/news/dtos/news-response.dto.ts
+++ b/src/news/dtos/news-response.dto.ts
@@ -1,5 +1,5 @@
 export class NewsResponseDto {
-  id: string;
+  _id: string;
   title: string;
   summary: string;
   content: string;

--- a/src/news/mappers/news.mapper.ts
+++ b/src/news/mappers/news.mapper.ts
@@ -8,7 +8,7 @@ import { PaginatedResult } from '@common/types/paginated-result';
 export class NewsMapper {
   toNewsResponseDto(news: News): NewsResponseDto {
     return {
-      id: news._id.toString(),
+      _id: news._id.toString(),
       title: news.title,
       summary: news.summary,
       content: news.content,

--- a/src/student-company-contract/dtos/create-student-company-contract-request.dto.ts
+++ b/src/student-company-contract/dtos/create-student-company-contract-request.dto.ts
@@ -1,0 +1,52 @@
+import {
+    IsDate,
+    IsEnum,
+    IsMongoId,
+    IsNotEmpty,
+    IsOptional,
+    IsString,
+    ValidateIf,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import { StudentCompanyContractStatus } from '../enums/student-company-contract-status.enum';
+import { StudentCompanyContractCancelledBy } from '../enums/student-company-contract-cancelled-by.enum';
+
+export class CreateStudentCompanyContractRequestDto {
+    @IsMongoId()
+    @IsNotEmpty()
+    student: string;
+
+    @IsMongoId()
+    @IsNotEmpty()
+    company: string;
+
+    @IsEnum(StudentCompanyContractStatus)
+    status: StudentCompanyContractStatus;
+
+    @IsOptional()
+    @Type(() => Date)
+    @IsDate()
+    startDate?: Date;
+
+    @IsOptional()
+    @Type(() => Date)
+    @IsDate()
+    endDate?: Date;
+
+    @IsOptional()
+    isPaid?: boolean;
+
+    @ValidateIf(o => o.status === StudentCompanyContractStatus.CANCELLED)
+    @IsNotEmpty()
+    @IsString()
+    cancellationReason?: string;
+
+    @ValidateIf(o => o.status === StudentCompanyContractStatus.CANCELLED)
+    @Type(() => Date)
+    @IsDate()
+    cancellationDate?: Date;
+
+    @ValidateIf(o => o.status === StudentCompanyContractStatus.CANCELLED)
+    @IsEnum(StudentCompanyContractCancelledBy)
+    cancelledBy?: StudentCompanyContractCancelledBy;
+}


### PR DESCRIPTION
This pull request includes changes to update field naming conventions in the `NewsResponseDto` class and related mapper, as well as the addition of a new DTO for managing student-company contracts. The most important changes are grouped below by theme.

### Field Naming Updates:

* **`src/news/dtos/news-response.dto.ts`:** Renamed the `id` field to `_id` in the `NewsResponseDto` class to align with MongoDB's default field naming conventions.
* **`src/news/mappers/news.mapper.ts`:** Updated the `toNewsResponseDto` method to reflect the field name change from `id` to `_id` when mapping the `News` entity to the `NewsResponseDto`.

### Addition of New DTO:

* **`src/student-company-contract/dtos/create-student-company-contract-request.dto.ts`:** Added the `CreateStudentCompanyContractRequestDto` class for handling student-company contract creation requests. This includes validation rules for fields such as `student`, `company`, `status`, `startDate`, `endDate`, and optional cancellation-related fields.