### PR TITLE
Feature/practice template

### DIFF
--- a/src/file/constants/file.constants.ts
+++ b/src/file/constants/file.constants.ts
@@ -19,4 +19,5 @@ export const FILE_FOLDERS = {
   COMPANY_CONTRACTS: 'company-contracts',
   NEWS: 'news',
   STUDENT_COMPANY_CONTRACTS: 'student-company-contracts',
+  PRACTICE_TEMPLATE_FORMATS: 'practice-template-formats',
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,7 @@ async function bootstrap() {
   app.useGlobalPipes(
     new ValidationPipe({
       whitelist: true,
+      transform: true,
     }),
   );
   app.setGlobalPrefix('api');

--- a/src/practice-template/constants/practice-template.constants.ts
+++ b/src/practice-template/constants/practice-template.constants.ts
@@ -1,0 +1,17 @@
+import { HttpStatus } from "@nestjs/common";
+
+export const PRACTICE_TEMPLATE_EXCEPTIONS = {
+    NOT_FOUND: {
+        code: 'PRACTICE_TEMPLATE_NOT_FOUND',
+        message: 'Practice template not found',
+        status: HttpStatus.NOT_FOUND
+    }
+}
+export const PRACTICE_TEMPLATE_SORT_OPTIONS = ['name', 'createdAt'];
+
+export const DEFAULT_PRACTICE_TEMPLATE_SORT_OPTION = 'name';
+
+export const PRACTICE_TEMPLATE_POPULATE_OPTIONS = {
+    DELIVERABLES: 'deliverables',
+    FORMATS: 'formats'
+}

--- a/src/practice-template/dtos/create-practice-template-request.dto.ts
+++ b/src/practice-template/dtos/create-practice-template-request.dto.ts
@@ -1,0 +1,11 @@
+import { IsNotEmpty, IsOptional, IsString } from "class-validator";
+
+export class CreatePracticeTemplateRequestDto {
+  @IsString()
+  @IsNotEmpty()
+  name: string;
+
+  @IsOptional()
+  @IsString()
+  description?: string;
+}

--- a/src/practice-template/dtos/practice-deliverable-response.dto.ts
+++ b/src/practice-template/dtos/practice-deliverable-response.dto.ts
@@ -1,0 +1,5 @@
+export class PracticeTemplateDeliverableResponseDto {
+    title: string;
+    description?: string;
+    estimatedDueOffsetDays: number;
+}

--- a/src/practice-template/dtos/practice-format-response.dto.ts
+++ b/src/practice-template/dtos/practice-format-response.dto.ts
@@ -1,0 +1,5 @@
+export class PracticeTemplateFormatResponseDto {
+    name: string;
+    description: string;
+    fileUrl: string;
+}

--- a/src/practice-template/dtos/practice-template-delliverable.dto.ts
+++ b/src/practice-template/dtos/practice-template-delliverable.dto.ts
@@ -1,0 +1,14 @@
+import { IsInt, IsNotEmpty, IsOptional, IsString } from "class-validator";
+
+export class PracticeTemplateDeliverableDto {
+  @IsString()
+  @IsNotEmpty()
+  title: string;
+
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @IsInt()
+  estimatedDueOffsetDays: number;
+}

--- a/src/practice-template/dtos/practice-template-filter.dto.ts
+++ b/src/practice-template/dtos/practice-template-filter.dto.ts
@@ -1,0 +1,5 @@
+import { PaginationQueryDto } from "@common/dtos/pagination-query.dto";
+
+export class PracticeTemplateFilterDto extends PaginationQueryDto {
+    name?: string;
+}

--- a/src/practice-template/dtos/practice-template-format.dto.ts
+++ b/src/practice-template/dtos/practice-template-format.dto.ts
@@ -1,0 +1,13 @@
+import { IsNotEmpty, IsString } from "class-validator";
+
+export class PracticeTemplateFormatDto {
+  @IsString()
+  @IsNotEmpty()
+  name: string;
+
+  @IsString()
+  @IsNotEmpty()
+  description: string;
+
+  fileUrl?: string;
+}

--- a/src/practice-template/dtos/practice-template-response.dto.ts
+++ b/src/practice-template/dtos/practice-template-response.dto.ts
@@ -1,0 +1,12 @@
+import { PracticeTemplateDeliverableResponseDto } from './practice-deliverable-response.dto';
+import { PracticeTemplateFormatResponseDto } from './practice-format-response.dto';
+
+export class PracticeTemplateResponseDto {
+    _id: string;
+    name: string;
+    description?: string;
+    deliverables: PracticeTemplateDeliverableResponseDto[];
+    formats: PracticeTemplateFormatResponseDto[];
+    createdAt: Date;
+    updatedAt: Date;
+}

--- a/src/practice-template/dtos/update-practice-template-request.dto.ts
+++ b/src/practice-template/dtos/update-practice-template-request.dto.ts
@@ -1,0 +1,4 @@
+export class UpdatePracticeTemplateRequestDto {
+    name?: string;
+    description?: string;
+}

--- a/src/practice-template/exceptions/practice-template-not-found.exception.ts
+++ b/src/practice-template/exceptions/practice-template-not-found.exception.ts
@@ -1,0 +1,12 @@
+import { BaseHttpException } from "@common/exceptions/base-http.exception";
+import { PRACTICE_TEMPLATE_EXCEPTIONS } from "practice-template/constants/practice-template.constants";
+
+export class PracticeTemplateNotFoundException extends BaseHttpException { 
+    constructor(){
+        super(
+            PRACTICE_TEMPLATE_EXCEPTIONS.NOT_FOUND.code,
+            PRACTICE_TEMPLATE_EXCEPTIONS.NOT_FOUND.message,
+            PRACTICE_TEMPLATE_EXCEPTIONS.NOT_FOUND.status
+        )
+    }
+}

--- a/src/practice-template/mappers/practice-template-mapper.ts
+++ b/src/practice-template/mappers/practice-template-mapper.ts
@@ -1,0 +1,36 @@
+import { Injectable } from "@nestjs/common";
+import { PracticeTemplateResponseDto } from "practice-template/dtos/practice-template-response.dto";
+import { PracticeTemplate, PracticeTemplateDocument } from "practice-template/schemas/practice-template.schema";
+
+@Injectable()
+export class PracticeTemplateMapper {
+    toResponseDto(
+        doc: PracticeTemplateDocument & { deliverables?: any[]; formats?: any[] }
+    ): PracticeTemplateResponseDto {
+        return {
+            _id: doc._id.toString(),
+            name: doc.name,
+            description: doc.description,
+            deliverables: (doc.deliverables || []).map(d => ({
+                _id: d._id.toString(),
+                template: doc._id.toString(),
+                title: d.title,
+                description: d.description,
+                estimatedDueOffsetDays: d.estimatedDueOffsetDays,
+                createdAt: d.createdAt,
+                updatedAt: d.updatedAt,
+            })),
+            formats: (doc.formats || []).map(f => ({
+                _id: f._id.toString(),
+                template: doc._id.toString(),
+                name: f.name,
+                description: f.description,
+                fileUrl: f.fileUrl,
+                createdAt: f.createdAt,
+                updatedAt: f.updatedAt,
+            })),
+            createdAt: doc.createdAt,
+            updatedAt: doc.updatedAt,
+        };
+    }
+}

--- a/src/practice-template/mappers/practice-template-mapper.ts
+++ b/src/practice-template/mappers/practice-template-mapper.ts
@@ -1,4 +1,6 @@
+import { PaginatedResult } from "@common/types/paginated-result";
 import { Injectable } from "@nestjs/common";
+import { PaginateResult } from "mongoose";
 import { PracticeTemplateResponseDto } from "practice-template/dtos/practice-template-response.dto";
 import { PracticeTemplate, PracticeTemplateDocument } from "practice-template/schemas/practice-template.schema";
 
@@ -31,6 +33,16 @@ export class PracticeTemplateMapper {
             })),
             createdAt: doc.createdAt,
             updatedAt: doc.updatedAt,
+        };
+    }
+
+    toPaginatedResponseDto(docs: PaginateResult<PracticeTemplateDocument>): PaginatedResult<PracticeTemplateResponseDto> {
+        return {
+            docs: docs.docs.map(doc => this.toResponseDto(doc)),
+            totalDocs: docs.totalDocs,
+            totalPages: docs.totalPages,
+            page: docs.page,
+            limit: docs.limit,
         };
     }
 }

--- a/src/practice-template/practice-template.controller.spec.ts
+++ b/src/practice-template/practice-template.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PracticeTemplateController } from './practice-template.controller';
+
+describe('PracticeTemplateController', () => {
+  let controller: PracticeTemplateController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [PracticeTemplateController],
+    }).compile();
+
+    controller = module.get<PracticeTemplateController>(PracticeTemplateController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/practice-template/practice-template.controller.ts
+++ b/src/practice-template/practice-template.controller.ts
@@ -1,17 +1,83 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Post,
+  Put,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
 import { PracticeTemplateService } from './practice-template.service';
-import { PracticeTemplateResponseDto } from './dtos/practice-template-response.dto';
+import { AuthGuard } from '@auth/guards/auth.guard';
+import { RoleGuard } from '@auth/guards/role.guard';
+import { UserRole } from '@common/enums/role.enum';
+import { Roles } from '@common/decorators/role.decorator';
 import { CreatePracticeTemplateRequestDto } from './dtos/create-practice-template-request.dto';
+import { PracticeTemplateResponseDto } from './dtos/practice-template-response.dto';
+import { TypeaheadItem } from '@common/dtos/typeahead-item.dto';
+import { PracticeTemplateFilterDto } from './dtos/practice-template-filter.dto';
+import { PaginatedResult } from '@common/types/paginated-result';
+import { ParseObjectIdPipe } from '@nestjs/mongoose';
+import { UpdatePracticeTemplateRequestDto } from './dtos/update-practice-template-request.dto';
 
 @Controller('practice-templates')
 export class PracticeTemplateController {
+  constructor(
+    private readonly service: PracticeTemplateService,
+  ) {}
 
-    constructor(private readonly practiceTemplateService: PracticeTemplateService) { }
+  @Post('create')
+  @UseGuards(AuthGuard, RoleGuard)
+  @Roles(UserRole.ADMIN)
+  async create(
+    @Body() dto: CreatePracticeTemplateRequestDto,
+  ): Promise<PracticeTemplateResponseDto> {
+    return this.service.createTemplate(dto);
+  }
 
-    @Post('create')
-    async create(
-        @Body() dto: CreatePracticeTemplateRequestDto,
-    ): Promise<PracticeTemplateResponseDto> {
-        return this.practiceTemplateService.createTemplate(dto);
-    }
+  @Get('typeahead')
+  @UseGuards(AuthGuard)
+  async getTypeahead(
+    @Query('query') query: string,
+  ): Promise<TypeaheadItem[]> {
+    return this.service.getTypeahead(query);
+  }
+
+  @Get()
+  @UseGuards(AuthGuard, RoleGuard)
+  @Roles(UserRole.ADMIN)
+  async getByCriteria(
+    @Query() filter: PracticeTemplateFilterDto,
+  ): Promise<PaginatedResult<PracticeTemplateResponseDto>> {
+    return this.service.getByCriteria(filter);
+  }
+
+  @Get(':templateId')
+  @UseGuards(AuthGuard)
+  async getById(
+    @Param('templateId', ParseObjectIdPipe) templateId: string,
+  ): Promise<PracticeTemplateResponseDto> {
+    return this.service.getTemplateById(templateId);
+  }
+
+  @Put('update/:templateId')
+  @UseGuards(AuthGuard, RoleGuard)
+  @Roles(UserRole.ADMIN)
+  async update(
+    @Param('templateId', ParseObjectIdPipe) templateId: string,
+    @Body() dto: UpdatePracticeTemplateRequestDto,
+  ): Promise<PracticeTemplateResponseDto> {
+    return this.service.updateTemplate(templateId, dto);
+  }
+
+  @Delete('delete/:templateId')
+  @UseGuards(AuthGuard, RoleGuard)
+  @Roles(UserRole.ADMIN)
+  async remove(
+    @Param('templateId', ParseObjectIdPipe) templateId: string,
+  ): Promise<void> {
+    return this.service.deleteTemplate(templateId);
+  }
 }

--- a/src/practice-template/practice-template.controller.ts
+++ b/src/practice-template/practice-template.controller.ts
@@ -1,0 +1,17 @@
+import { Body, Controller, Post } from '@nestjs/common';
+import { PracticeTemplateService } from './practice-template.service';
+import { PracticeTemplateResponseDto } from './dtos/practice-template-response.dto';
+import { CreatePracticeTemplateRequestDto } from './dtos/create-practice-template-request.dto';
+
+@Controller('practice-templates')
+export class PracticeTemplateController {
+
+    constructor(private readonly practiceTemplateService: PracticeTemplateService) { }
+
+    @Post('create')
+    async create(
+        @Body() dto: CreatePracticeTemplateRequestDto,
+    ): Promise<PracticeTemplateResponseDto> {
+        return this.practiceTemplateService.createTemplate(dto);
+    }
+}

--- a/src/practice-template/practice-template.module.ts
+++ b/src/practice-template/practice-template.module.ts
@@ -1,4 +1,23 @@
 import { Module } from '@nestjs/common';
+import { PracticeTemplateService } from './practice-template.service';
+import { PracticeTemplateController } from './practice-template.controller';
+import { MongooseModule } from '@nestjs/mongoose';
+import { PracticeTemplate, PracticeTemplateSchema } from './schemas/practice-template.schema';
+import { AuthModule } from '@auth/auth.module';
+import { FileModule } from 'file/file.module';
+import { PracticeTemplateMapper } from './mappers/practice-template-mapper';
 
-@Module({})
-export class PracticeTemplateModule {}
+@Module({
+  imports: [MongooseModule.forFeature([
+    {
+      name: PracticeTemplate.name,
+      schema: PracticeTemplateSchema,
+    }
+  ]),
+    AuthModule,
+    FileModule
+  ],
+  providers: [PracticeTemplateService, PracticeTemplateMapper],
+  controllers: [PracticeTemplateController],
+})
+export class PracticeTemplateModule { }

--- a/src/practice-template/practice-template.service.spec.ts
+++ b/src/practice-template/practice-template.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PracticeTemplateService } from './practice-template.service';
+
+describe('PracticeTemplateService', () => {
+  let service: PracticeTemplateService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [PracticeTemplateService],
+    }).compile();
+
+    service = module.get<PracticeTemplateService>(PracticeTemplateService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/practice-template/practice-template.service.ts
+++ b/src/practice-template/practice-template.service.ts
@@ -12,6 +12,7 @@ import { PracticeTemplateFilterDto } from './dtos/practice-template-filter.dto';
 import { DEFAULT_PRACTICE_TEMPLATE_SORT_OPTION, PRACTICE_TEMPLATE_POPULATE_OPTIONS, PRACTICE_TEMPLATE_SORT_OPTIONS } from './constants/practice-template.constants';
 import { UpdatePracticeTemplateRequestDto } from './dtos/update-practice-template-request.dto';
 import { MAX_TYPEAHEAD_ITEMS } from '@common/constants/constaint.constants';
+import { PaginatedResult } from '@common/types/paginated-result';
 
 @Injectable()
 export class PracticeTemplateService {
@@ -46,7 +47,7 @@ export class PracticeTemplateService {
 
     async getByCriteria(
         filter: PracticeTemplateFilterDto,
-    ): Promise<PaginateResult<PracticeTemplateResponseDto>> {
+    ): Promise<PaginatedResult<PracticeTemplateResponseDto>> {
         const { page, limit, sortBy, sortOrder, name } = filter;
         const query: any = {};
         if (name) query.name = new RegExp(name, 'i');
@@ -65,10 +66,7 @@ export class PracticeTemplateService {
                 PRACTICE_TEMPLATE_POPULATE_OPTIONS.FORMATS],
         });
 
-        return {
-            ...result,
-            docs: result.docs.map(doc => this.mapper.toResponseDto(doc)),
-        };
+        return this.mapper.toPaginatedResponseDto(result);
     }
 
     async updateTemplate(
@@ -85,8 +83,10 @@ export class PracticeTemplateService {
     }
 
     async deleteTemplate(id: string): Promise<void> {
-        const res = await this.templateModel.findByIdAndDelete(id).exec();
-        if (!res) throw new PracticeTemplateNotFoundException();
+        const template = await this.templateModel.findById(id);
+        if (!template) throw new PracticeTemplateNotFoundException();
+
+        await template.softDelete();
     }
 
     async validateTemplateExists(id: string): Promise<void> {

--- a/src/practice-template/practice-template.service.ts
+++ b/src/practice-template/practice-template.service.ts
@@ -1,0 +1,104 @@
+import { Injectable } from '@nestjs/common';
+import { PaginateModel, PaginateResult } from 'mongoose';
+import { PracticeTemplate, PracticeTemplateDocument } from './schemas/practice-template.schema';
+import { PracticeTemplateNotFoundException } from './exceptions/practice-template-not-found.exception';
+import { getSort } from '@common/utils/pagination.util';
+import { TypeaheadItem } from '@common/dtos/typeahead-item.dto';
+import { InjectModel } from '@nestjs/mongoose';
+import { PracticeTemplateMapper } from './mappers/practice-template-mapper';
+import { CreatePracticeTemplateRequestDto } from './dtos/create-practice-template-request.dto';
+import { PracticeTemplateResponseDto } from './dtos/practice-template-response.dto';
+import { PracticeTemplateFilterDto } from './dtos/practice-template-filter.dto';
+import { DEFAULT_PRACTICE_TEMPLATE_SORT_OPTION, PRACTICE_TEMPLATE_POPULATE_OPTIONS, PRACTICE_TEMPLATE_SORT_OPTIONS } from './constants/practice-template.constants';
+import { UpdatePracticeTemplateRequestDto } from './dtos/update-practice-template-request.dto';
+import { MAX_TYPEAHEAD_ITEMS } from '@common/constants/constaint.constants';
+
+@Injectable()
+export class PracticeTemplateService {
+    constructor(
+        @InjectModel(PracticeTemplate.name)
+        private readonly templateModel: PaginateModel<PracticeTemplateDocument>,
+        private readonly mapper: PracticeTemplateMapper,
+    ) { }
+
+    async createTemplate(
+        dto: CreatePracticeTemplateRequestDto,
+    ): Promise<PracticeTemplateResponseDto> {
+        const doc = new this.templateModel(dto);
+        const saved = await doc.save();
+        const populated = await saved
+            .populate([
+                PRACTICE_TEMPLATE_POPULATE_OPTIONS.DELIVERABLES,
+                PRACTICE_TEMPLATE_POPULATE_OPTIONS.FORMATS]);
+
+        return this.mapper.toResponseDto(populated);
+    }
+
+    async getTemplateById(id: string): Promise<PracticeTemplateResponseDto> {
+        const doc = await this.templateModel
+            .findById(id)
+            .populate('deliverables')
+            .populate('formats')
+            .exec();
+        if (!doc) throw new PracticeTemplateNotFoundException();
+        return this.mapper.toResponseDto(doc);
+    }
+
+    async getByCriteria(
+        filter: PracticeTemplateFilterDto,
+    ): Promise<PaginateResult<PracticeTemplateResponseDto>> {
+        const { page, limit, sortBy, sortOrder, name } = filter;
+        const query: any = {};
+        if (name) query.name = new RegExp(name, 'i');
+
+        const sort = getSort(
+            PRACTICE_TEMPLATE_SORT_OPTIONS,
+            DEFAULT_PRACTICE_TEMPLATE_SORT_OPTION,
+            sortBy,
+            sortOrder,
+        );
+
+        const result: PaginateResult<PracticeTemplateDocument> = await this.templateModel.paginate(query, {
+            page, limit, sort,
+            populate: [
+                PRACTICE_TEMPLATE_POPULATE_OPTIONS.DELIVERABLES,
+                PRACTICE_TEMPLATE_POPULATE_OPTIONS.FORMATS],
+        });
+
+        return {
+            ...result,
+            docs: result.docs.map(doc => this.mapper.toResponseDto(doc)),
+        };
+    }
+
+    async updateTemplate(
+        id: string,
+        dto: UpdatePracticeTemplateRequestDto,
+    ): Promise<PracticeTemplateResponseDto> {
+        const doc = await this.templateModel.findByIdAndUpdate(id, dto, { new: true })
+            .populate([
+                PRACTICE_TEMPLATE_POPULATE_OPTIONS.DELIVERABLES,
+                PRACTICE_TEMPLATE_POPULATE_OPTIONS.FORMATS])
+            .exec();
+        if (!doc) throw new PracticeTemplateNotFoundException();
+        return this.mapper.toResponseDto(doc);
+    }
+
+    async deleteTemplate(id: string): Promise<void> {
+        const res = await this.templateModel.findByIdAndDelete(id).exec();
+        if (!res) throw new PracticeTemplateNotFoundException();
+    }
+
+    async validateTemplateExists(id: string): Promise<void> {
+        const exists = await this.templateModel.exists({ _id: id });
+        if (!exists) throw new PracticeTemplateNotFoundException();
+    }
+
+    async getTypeahead(query: string): Promise<TypeaheadItem[]> {
+        const docs = await this.templateModel
+            .find({ name: { $regex: `^${query}`, $options: 'i' } })
+            .limit(MAX_TYPEAHEAD_ITEMS)
+            .exec();
+        return docs.map(doc => ({ label: doc.name, value: doc._id.toString() }));
+    }
+}

--- a/src/practice-template/schemas/practice-template-deliverable.schema.ts
+++ b/src/practice-template/schemas/practice-template-deliverable.schema.ts
@@ -1,8 +1,19 @@
+import { BaseSchema } from '@common/types/base.schema';
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import { Document } from 'mongoose';
 
 @Schema({ _id: false })
-export class PracticeTemplateDeliverable {
+export class PracticeTemplateDeliverable extends BaseSchema {
+
+    @Prop({
+        type: String,
+        required: true,
+        set: (v: any) => {
+            return typeof v === 'string' ? v : v.toString();
+        },
+    })
+    template: string;
+
     @Prop({ required: true })
     title: string;
 

--- a/src/practice-template/schemas/practice-template-format.schema.ts
+++ b/src/practice-template/schemas/practice-template-format.schema.ts
@@ -1,7 +1,18 @@
+import { BaseSchema } from "@common/types/base.schema";
 import { Prop, Schema, SchemaFactory } from "@nestjs/mongoose";
+import { Types } from "mongoose";
 
-@Schema({ _id: false })
-export class PracticeTemplateFormat {
+@Schema({ timestamps: true })
+export class PracticeTemplateFormat extends BaseSchema {
+    @Prop({
+        type: Types.ObjectId,
+        ref: PracticeTemplateFormat.name,
+        required: false,
+        set: (v: any) =>
+            typeof v === 'string' ? new Types.ObjectId(v) : v,
+    })
+    template: Types.ObjectId;
+
     @Prop({ required: true })
     name: string;
 

--- a/src/practice-template/schemas/practice-template.schema.ts
+++ b/src/practice-template/schemas/practice-template.schema.ts
@@ -1,29 +1,18 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
-import {
-  PracticeTemplateDeliverable,
-  PracticeTemplateDeliverableSchema
-} from './practice-template-deliverable.schema';
-import {
-  PracticeTemplateFormat,
-  PracticeTemplateFormatSchema
-} from './practice-template-format.schema';
 import { SoftDeletableDocument } from '@common/types/soft-deletable-document';
 import { softDeletePlugin } from '@common/plugins/soft-delete.plugin';
 import * as mongoosePaginate from 'mongoose-paginate-v2';
+import { BaseSchema } from '@common/types/base.schema';
+import { PracticeTemplateDeliverable } from './practice-template-deliverable.schema';
+import { PracticeTemplateFormat } from './practice-template-format.schema';
 
 @Schema({ timestamps: true })
-export class PracticeTemplate {
+export class PracticeTemplate extends BaseSchema {
   @Prop({ required: true })
   name: string;
 
   @Prop()
   description?: string;
-
-  @Prop({ type: [PracticeTemplateDeliverableSchema], default: [] })
-  deliverables: PracticeTemplateDeliverable[];
-
-  @Prop({ type: [PracticeTemplateFormatSchema], default: [] })
-  formats: PracticeTemplateFormat[];
 }
 
 export type PracticeTemplateDocument = SoftDeletableDocument<PracticeTemplate>;
@@ -31,3 +20,14 @@ export const PracticeTemplateSchema = SchemaFactory.createForClass(PracticeTempl
 
 PracticeTemplateSchema.plugin(mongoosePaginate);
 PracticeTemplateSchema.plugin(softDeletePlugin);
+PracticeTemplateSchema.virtual('deliverables', {
+  ref: PracticeTemplateDeliverable.name,
+  localField: '_id',
+  foreignField: 'template',
+});
+
+PracticeTemplateSchema.virtual('formats', {
+  ref: PracticeTemplateFormat.name,
+  localField: '_id',
+  foreignField: 'template',
+});


### PR DESCRIPTION
This pull request introduces a new feature for managing "Practice Templates" in the application. It includes the implementation of controllers, services, DTOs, schemas, constants, and exception handling for this feature. Additionally, minor improvements were made to the global validation pipe configuration. Below is a categorized summary of the most important changes:

### New Feature: Practice Templates

* **Controller and Service Implementation**:
  - Added `PracticeTemplateController` with endpoints for creating, retrieving, updating, and deleting practice templates, including typeahead and paginated filtering. (`src/practice-template/practice-template.controller.ts`)
  - Implemented `PracticeTemplateService` to handle business logic for managing practice templates, including CRUD operations and typeahead functionality. (`src/practice-template/practice-template.service.ts`)

* **Data Transfer Objects (DTOs)**:
  - Introduced several DTOs for requests and responses, such as `CreatePracticeTemplateRequestDto`, `PracticeTemplateResponseDto`, `PracticeTemplateFilterDto`, and others. These ensure consistent data structures for API communication. [[1]](diffhunk://#diff-de40afed97d6a8297e2dabfb017e62b1d36ef62bbaf6004e44c38cd6c66f177dR1-R11) [[2]](diffhunk://#diff-6274f057702cc3a66c4edadb0e92143f0cf72c96755e9009db185b1cc0a18fa4R1-R5) [[3]](diffhunk://#diff-1a6107516489627728905c8927e2de71df95d22997efffdafa592c51a3c6ddaaR1-R5) [[4]](diffhunk://#diff-6450b77c6a78459135b391859fe4069193a090e34b6952fe099269f84cc4eba6R1-R5) [[5]](diffhunk://#diff-572f645d98554471f0092069a5715716734a845890c68f67f9e0ee6eee7ba7a6R1-R12) [[6]](diffhunk://#diff-2bb8b0a57520e3f6746f9f98f547e9c3af80c3cc5b8039ee272e20448419f4b4R1-R4)

* **Schema and Database Integration**:
  - Defined Mongoose schemas for `PracticeTemplate`, `PracticeTemplateDeliverable`, and `PracticeTemplateFormat`, including relationships and validation. (`src/practice-template/schemas/practice-template.schema.ts`, `src/practice-template/schemas/practice-template-deliverable.schema.ts`, `src/practice-template/schemas/practice-template-format.schema.ts`) [[1]](diffhunk://#diff-2845ebfd8f79aa2c92e00b652c70bb6eb1473118f38e0c7eedfa9f29cae6728bR1-R16) [[2]](diffhunk://#diff-e2063d46c40e97d1b4d6a8d1f09e8e9a4bda8769cf6c5ba291af9caa58678b6cR1-L4)
  - Integrated the schemas into the `PracticeTemplateModule` using Mongoose. (`src/practice-template/practice-template.module.ts`)

* **Constants and Exception Handling**:
  - Added constants for practice template exceptions, sorting options, and population options to centralize configuration. (`src/practice-template/constants/practice-template.constants.ts`)
  - Created `PracticeTemplateNotFoundException` for consistent error handling when a template is not found. (`src/practice-template/exceptions/practice-template-not-found.exception.ts`)

### Codebase Improvements

* **Validation Pipe Update**:
  - Enabled the `transform` option in the global validation pipe to automatically transform request payloads into DTO instances. (`src/main.ts`)

* **New Mapper**:
  - Added `PracticeTemplateMapper` to handle conversion between database documents and response DTOs, including support for paginated results. (`src/practice-template/mappers/practice-template-mapper.ts`)

These changes collectively add a robust feature for managing practice templates while improving the application's modularity and maintainability.