### PR TITLE
Feature/practice process

### DIFF
--- a/src/practice-process/constants/practice-process.constants.ts
+++ b/src/practice-process/constants/practice-process.constants.ts
@@ -58,6 +58,12 @@ export const PRACTICE_PROCESS_POPULATE_OPTIONS = {
     },
     COMPANY: {
         path: 'company',
+    },
+    DELIVERABLES: {
+        path: 'deliverables',
+    },
+    FOLLOW_UPS: {
+        path: 'followUps',
     }
 }
 

--- a/src/practice-process/controllers/practice-process.controller.ts
+++ b/src/practice-process/controllers/practice-process.controller.ts
@@ -1,8 +1,10 @@
 import { AuthGuard } from '@auth/guards/auth.guard';
 import { RoleGuard } from '@auth/guards/role.guard';
+import { CurrentUser } from '@common/decorators/current-user.decorator';
 import { Roles } from '@common/decorators/role.decorator';
 import { UserRole } from '@common/enums/role.enum';
 import { Body, Controller, Delete, Get, Param, Post, Query, UseGuards } from '@nestjs/common';
+import { ParseObjectIdPipe } from '@nestjs/mongoose';
 import { CancelPracticeProcessRequestDto } from 'practice-process/dtos/cancel-practice-process.request.dto';
 import { PracticeProcessFilterDto } from 'practice-process/dtos/practice-process-filter.dto';
 import { StartPracticeProcessRequestDto } from 'practice-process/dtos/start-practice-process-request.dto';
@@ -28,7 +30,7 @@ export class PracticeProcessController {
     @UseGuards(AuthGuard, RoleGuard)
     @Roles(UserRole.ADMIN)
     async cancelPracticeProcess(
-        @Param('processId') processId: string,
+        @Param('processId', ParseObjectIdPipe) processId: string,
         @Body() cancelPracticeProcessRequestDto: CancelPracticeProcessRequestDto
     ) {
         return this.practiceProcessService.cancelPracticeProcess(processId, cancelPracticeProcessRequestDto);
@@ -44,11 +46,30 @@ export class PracticeProcessController {
         return this.practiceProcessService.getPracticeProcessesByCriteria(filter);
     }
 
+    @Get(':processId')
+    @UseGuards(AuthGuard)
+    async getPracticeProcessById(
+        @CurrentUser() userId: string,
+        @Param('processId', ParseObjectIdPipe) processId: string
+    ) {
+        return this.practiceProcessService.getPracticeProcessById(userId, processId);
+    }
+
+    @Get('student/me/current')
+    @UseGuards(AuthGuard, RoleGuard)
+    @Roles(UserRole.STUDENT)
+    async getCurrentPracticeProcessForStudent(
+        @CurrentUser() studentId: string
+    ) {
+        return this.practiceProcessService.getCurrentPracticeProcessForStudent(studentId);
+    }
+
+
     @Delete('delete/:processId')
     @UseGuards(AuthGuard, RoleGuard)
     @Roles(UserRole.ADMIN)
     async deletePracticeProcess(
-        @Param('processId') processId: string
+        @Param('processId', ParseObjectIdPipe) processId: string
     ) {
         return this.practiceProcessService.deletePracticeProcess(processId);
     }

--- a/src/practice-process/dtos/practice-process-deliverable-response.dto.ts
+++ b/src/practice-process/dtos/practice-process-deliverable-response.dto.ts
@@ -1,0 +1,12 @@
+import { PracticeProcessDeliverableStatus } from "practice-process/enums/practice-process-deliverable.enums";
+
+export interface PracticeProcessDeliverableResponseDto {
+    _id: string;
+    dueDate: Date;
+    submittedAt?: Date;
+    submissionUrl?: string;
+    status: PracticeProcessDeliverableStatus;
+    grade?: number;
+    gradeObservations?: string;
+    gradedAt?: Date;
+}

--- a/src/practice-process/dtos/practice-process-detail-response.dto.ts
+++ b/src/practice-process/dtos/practice-process-detail-response.dto.ts
@@ -1,0 +1,8 @@
+import { PracticeProcessDeliverableResponseDto } from "./practice-process-deliverable-response.dto";
+import { PracticeProcessFollowUpResponseDto } from "./practice-process-follow-up-response.dto";
+import { PracticeProcessResponseDto } from "./practice-process-response.dto";
+
+export class PracticeProcessDetailResponseDto extends PracticeProcessResponseDto {
+    deliverables: PracticeProcessDeliverableResponseDto[];
+    followUps: PracticeProcessFollowUpResponseDto[];
+}

--- a/src/practice-process/dtos/practice-process-follow-up-response.dto.ts
+++ b/src/practice-process/dtos/practice-process-follow-up-response.dto.ts
@@ -1,0 +1,12 @@
+import { FollowUpStatus } from "practice-process/enums/practice-process-follow-up.enum";
+
+export interface PracticeProcessFollowUpResponseDto {
+    _id: string;
+    status: FollowUpStatus;
+    date: Date;
+    outcomeNotes?: string;
+    completedAt?: Date;
+    cancelledAt?: Date;
+    cancellationReason?: string;
+    missedNotes?: string;
+}

--- a/src/practice-process/mappers/practice-process.mapper.ts
+++ b/src/practice-process/mappers/practice-process.mapper.ts
@@ -5,7 +5,10 @@ import { Company } from "company/schemas/company.schema";
 import { PaginateResult } from "mongoose";
 import { PracticeDefinitionMapper } from "practice-definition/mappers/practice-definition.mapper";
 import { PracticeDefinition } from "practice-definition/schemas/practice-definition.schema";
+import { PracticeProcessDetailResponseDto } from "practice-process/dtos/practice-process-detail-response.dto";
 import { PracticeProcessResponseDto } from "practice-process/dtos/practice-process-response.dto";
+import { PracticeProcessDeliverable } from "practice-process/schemas/practice-process-deliverable.schema";
+import { PracticeProcessFollowUp } from "practice-process/schemas/practice-process-follow-up.schema";
 import { PracticeProcess } from "practice-process/schemas/practice-process.schema";
 import { ProfessorMapper } from "professor/mappers/professor.mapper";
 import { Professor } from "professor/schemas/professor.schema";
@@ -38,7 +41,33 @@ export class PracticeProcessMapper {
             cancellationReason: practiceProcess.cancellationReason,
             createdAt: practiceProcess.createdAt,
             updatedAt: practiceProcess.updatedAt,
-            //TODO Deliverables and FollowUps should be added here when implemented
+        };
+    }
+
+    toDetailedResponseDto(practiceProcess: PracticeProcess & { deliverables: PracticeProcessDeliverable[], followUps: PracticeProcessFollowUp[] }): PracticeProcessDetailResponseDto {
+        return {
+            ...this.toResponseDto(practiceProcess),
+            deliverables: practiceProcess.deliverables.map(deliverable => ({
+                _id: deliverable._id.toString(),
+                dueDate: deliverable.dueDate,
+                submittedAt: deliverable.submittedAt,
+                submissionUrl: deliverable.submissionUrl,
+                status: deliverable.status,
+                grade: deliverable.grade,
+                gradeObservations: deliverable.gradeObservations,
+                gradedAt: deliverable.gradedAt,
+            })),
+            followUps: practiceProcess.followUps.map(followUp => ({
+                _id: followUp._id.toString(),
+                status: followUp.status,
+                date: followUp.date,
+                outcomeNotes: followUp.outcomeNotes,
+                completedAt: followUp.completedAt,
+                cancelledAt: followUp.cancelledAt,
+                cancellationReason: followUp.cancellationReason,
+                missedNotes: followUp.missedNotes,
+            })),
+
         };
     }
 

--- a/src/practice-process/practice-process.module.ts
+++ b/src/practice-process/practice-process.module.ts
@@ -10,6 +10,7 @@ import { StudentModule } from 'student/student.module';
 import { CompanyModule } from 'company/company.module';
 import { PracticeProcessMapper } from './mappers/practice-process.mapper';
 import { AuthModule } from '@auth/auth.module';
+import { PracticeProcessFollowUp, PracticeProcessFollowUpSchema } from './schemas/practice-process-follow-up.schema';
 
 @Module({
   imports: [
@@ -21,6 +22,10 @@ import { AuthModule } from '@auth/auth.module';
       {
         name: PracticeProcessDeliverable.name,
         schema: PracticeProcessDeliverableSchema,
+      },
+      {
+        name: PracticeProcessFollowUp.name,
+        schema: PracticeProcessFollowUpSchema
       }
     ]),
     PracticeDefinitionModule,

--- a/src/practice-process/schemas/practice-process-deliverable.schema.ts
+++ b/src/practice-process/schemas/practice-process-deliverable.schema.ts
@@ -4,11 +4,11 @@ import { PracticeProcess } from "./practice-process.schema";
 import { PracticeTemplateDeliverable } from "practice-template/schemas/practice-template-deliverable.schema";
 import { PracticeProcessDeliverableStatus } from "practice-process/enums/practice-process-deliverable.enums";
 import { PRACTICE_PROCESS_DELIVERABLE_CONSTRAINTS } from "practice-process/constants/practice-process-deliverable.constants";
-import { Professor } from "professor/schemas/professor.schema";
 import * as mongoosePaginate from "mongoose-paginate-v2";
+import { BaseSchema } from "@common/types/base.schema";
 
 @Schema({ timestamps: true })
-export class PracticeProcessDeliverable {
+export class PracticeProcessDeliverable extends BaseSchema {
   @Prop({ type: Types.ObjectId, ref: PracticeProcess.name, required: true })
   process: Types.ObjectId;
 

--- a/src/student/student.controller.ts
+++ b/src/student/student.controller.ts
@@ -22,10 +22,11 @@ import { StudentFilterDto } from './dtos/student-filter.dto';
 import { ParseObjectIdPipe } from '@nestjs/mongoose';
 import { UpdateStudentRequestDto } from './dtos/update-student-request.dto';
 import { TypeaheadItem } from '@common/dtos/typeahead-item.dto';
+import { CurrentUser } from '@common/decorators/current-user.decorator';
 
 @Controller('students')
 export class StudentController {
-  constructor(private readonly studentService: StudentService) {}
+  constructor(private readonly studentService: StudentService) { }
 
   @Post('create')
   @UseGuards(AuthGuard, RoleGuard)
@@ -41,6 +42,15 @@ export class StudentController {
   @Roles(UserRole.ADMIN)
   async getStudentsByCriteria(@Query() filter: StudentFilterDto) {
     return await this.studentService.getStudentsByCriteria(filter);
+  }
+
+  @Get('/me')
+  @UseGuards(AuthGuard, RoleGuard)
+  @Roles(UserRole.STUDENT)
+  async getMyProfile(
+    @CurrentUser() studentId: string,
+  ): Promise<StudentResponseDto> {
+    return await this.studentService.getStudentById(studentId);
   }
 
   @Get('/typeahead')


### PR DESCRIPTION
This pull request introduces several enhancements to the `practice-process` module, including new features for handling deliverables and follow-ups, updates to controller methods, and the addition of new DTOs and schemas. It also introduces a new endpoint in the `student` module for retrieving the current student's profile. Below are the most important changes grouped by theme:

### Enhancements to Practice Process Module

* **Deliverables and Follow-Ups Integration**:
  - Added `DELIVERABLES` and `FOLLOW_UPS` to `PRACTICE_PROCESS_POPULATE_OPTIONS` for database population. (`src/practice-process/constants/practice-process.constants.ts`, [src/practice-process/constants/practice-process.constants.tsR61-R66](diffhunk://#diff-995374491d1753befeacb2cfd612d78942ad0e211a22cf912a15708ebafc5ed9R61-R66))
  - Introduced `PracticeProcessDeliverableResponseDto` and `PracticeProcessFollowUpResponseDto` DTOs for structured responses. (`src/practice-process/dtos/practice-process-deliverable-response.dto.ts`, [[1]](diffhunk://#diff-03d1e85fcd009ff7d2ce11c6ba9e7d84262649fc5db56e156c095d893ee2b127R1-R12); `src/practice-process/dtos/practice-process-follow-up-response.dto.ts`, [[2]](diffhunk://#diff-66fd531ac217da0e9caec400119f6ea8c1b219c6e83fa9c2a1a5fc33a9819177R1-R12)
  - Added `PracticeProcessDetailResponseDto` to include deliverables and follow-ups in detailed responses. (`src/practice-process/dtos/practice-process-detail-response.dto.ts`, [src/practice-process/dtos/practice-process-detail-response.dto.tsR1-R8](diffhunk://#diff-59646b932322d7f0622c524e60b50ea71afe4210a16245aeb4bc13507e346875R1-R8))
  - Updated `PracticeProcessMapper` to map deliverables and follow-ups fields for detailed responses. (`src/practice-process/mappers/practice-process.mapper.ts`, [src/practice-process/mappers/practice-process.mapper.tsL41-R70](diffhunk://#diff-930bad952b798be76d3c5e17abeeb7fb01db2638b13009942dffbf25a8b369a9L41-R70))

* **New Controller Methods**:
  - Added `getPracticeProcessById` and `getCurrentPracticeProcessForStudent` endpoints in `PracticeProcessController` for retrieving detailed process information and the current process for a student. (`src/practice-process/controllers/practice-process.controller.ts`, [src/practice-process/controllers/practice-process.controller.tsR49-R72](diffhunk://#diff-67710f9d89df7830826af86dae6a61fe7ef385a1295ee097220942cbdbe45e7dR49-R72))
  - Updated `cancelPracticeProcess` and `deletePracticeProcess` methods to use `ParseObjectIdPipe` for validating `processId`. (`src/practice-process/controllers/practice-process.controller.ts`, [[1]](diffhunk://#diff-67710f9d89df7830826af86dae6a61fe7ef385a1295ee097220942cbdbe45e7dL31-R33) [[2]](diffhunk://#diff-67710f9d89df7830826af86dae6a61fe7ef385a1295ee097220942cbdbe45e7dR49-R72)

* **Service Layer Updates**:
  - Implemented `getPracticeProcessById` and `getCurrentPracticeProcessForStudent` methods in `PracticeProcessService` for fetching detailed and current practice processes. (`src/practice-process/services/practice-process.service.ts`, [src/practice-process/services/practice-process.service.tsR137-R179](diffhunk://#diff-b9a029f7855d0f633e7e1e85923c0d802de8241b56a9ec824c609c9f3d2a56a9R137-R179))
  - Added population options for deliverables and follow-ups in service queries. (`src/practice-process/services/practice-process.service.ts`, [src/practice-process/services/practice-process.service.tsR137-R179](diffhunk://#diff-b9a029f7855d0f633e7e1e85923c0d802de8241b56a9ec824c609c9f3d2a56a9R137-R179))

### Updates to Student Module

* **Student Profile Endpoint**:
  - Added `getMyProfile` endpoint in `StudentController` for students to retrieve their own profile information. (`src/student/student.controller.ts`, [src/student/student.controller.tsR47-R55](diffhunk://#diff-815126b7554ff4bf5525dd7f338969e5fb038151ade4b4013e9661c5b87b5e04R47-R55))

### Schema Enhancements

* **Base Schema Integration**:
  - Updated `PracticeProcessDeliverable` schema to extend `BaseSchema` for consistent schema structure. (`src/practice-process/schemas/practice-process-deliverable.schema.ts`, [src/practice-process/schemas/practice-process-deliverable.schema.tsL7-R11](diffhunk://#diff-9a116a5ad5de28176345833a10a9d312c1c58aecb2388a7b63d5cdb8e1fdfee0L7-R11))

These changes collectively improve the functionality and structure of the `practice-process` module, enabling better handling of deliverables and follow-ups, and enhance the `student` module with a new profile endpoint.