### PR TITLE
feat(practice-process): include title and description in deliverables…

### DIFF
--- a/src/practice-process/dtos/practice-process-deliverable-response.dto.ts
+++ b/src/practice-process/dtos/practice-process-deliverable-response.dto.ts
@@ -2,6 +2,8 @@ import { PracticeProcessDeliverableStatus } from "practice-process/enums/practic
 
 export interface PracticeProcessDeliverableResponseDto {
     _id: string;
+    title: string;
+    description?: string;
     dueDate: Date;
     submittedAt?: Date;
     submissionUrl?: string;

--- a/src/practice-process/mappers/practice-process.mapper.ts
+++ b/src/practice-process/mappers/practice-process.mapper.ts
@@ -49,6 +49,8 @@ export class PracticeProcessMapper {
             ...this.toResponseDto(practiceProcess),
             deliverables: practiceProcess.deliverables.map(deliverable => ({
                 _id: deliverable._id.toString(),
+                title: deliverable.title,
+                description: deliverable.description,
                 dueDate: deliverable.dueDate,
                 submittedAt: deliverable.submittedAt,
                 submissionUrl: deliverable.submissionUrl,

--- a/src/practice-process/schemas/practice-process-deliverable.schema.ts
+++ b/src/practice-process/schemas/practice-process-deliverable.schema.ts
@@ -12,6 +12,12 @@ export class PracticeProcessDeliverable extends BaseSchema {
   @Prop({ type: Types.ObjectId, ref: PracticeProcess.name, required: true })
   process: Types.ObjectId;
 
+  @Prop({ required: true })
+  title: string;
+
+  @Prop()
+  description?: string;
+  
   @Prop({ type: Types.ObjectId, ref: PracticeTemplateDeliverable.name, required: true })
   templateDeliverable: Types.ObjectId;
 

--- a/src/practice-process/services/practice-process.service.ts
+++ b/src/practice-process/services/practice-process.service.ts
@@ -226,6 +226,8 @@ export class PracticeProcessService {
 
             return new this.practiceProcessDeliverableModel({
                 process: processId,
+                title: deliverable.title,
+                description: deliverable.description,
                 templateDeliverable: deliverable._id,
                 dueDate,
                 status: PracticeProcessStatus.PENDING


### PR DESCRIPTION
This pull request introduces changes to enhance the `PracticeProcessDeliverable` schema and related functionality by adding `title` and `description` fields. These updates ensure that deliverables have more descriptive metadata, improving their usability in the application.

### Enhancements to `PracticeProcessDeliverable` schema:

* [`src/practice-process/schemas/practice-process-deliverable.schema.ts`](diffhunk://#diff-9a116a5ad5de28176345833a10a9d312c1c58aecb2388a7b63d5cdb8e1fdfee0R15-R20): Added `title` (required) and `description` (optional) fields to the schema for better deliverable metadata.

### Updates to DTOs and mappers:

* [`src/practice-process/dtos/practice-process-deliverable-response.dto.ts`](diffhunk://#diff-03d1e85fcd009ff7d2ce11c6ba9e7d84262649fc5db56e156c095d893ee2b127R5-R6): Updated the DTO to include `title` and `description` fields for deliverable responses.
* [`src/practice-process/mappers/practice-process.mapper.ts`](diffhunk://#diff-930bad952b798be76d3c5e17abeeb7fb01db2638b13009942dffbf25a8b369a9R52-R53): Modified the mapper to map `title` and `description` fields from the schema to the response DTO.

### Service layer adjustments:

* [`src/practice-process/services/practice-process.service.ts`](diffhunk://#diff-b9a029f7855d0f633e7e1e85923c0d802de8241b56a9ec824c609c9f3d2a56a9R229-R230): Updated the service to set `title` and `description` when creating a new deliverable.… schema and response